### PR TITLE
Handle nullable types when transforming types

### DIFF
--- a/src/OpenApi.Extensions/Extensions/OpenApiOptionsExtensions.cs
+++ b/src/OpenApi.Extensions/Extensions/OpenApiOptionsExtensions.cs
@@ -202,7 +202,7 @@ public static class OpenApiOptionsExtensions
                 return Task.CompletedTask;
             }
 
-            schema.Type = typeof(TConcrete).Name;
+            schema.Type = GetTypeName<TConcrete>();
             schema.Example = new OpenApiString(FormatJson(Activator.CreateInstance<TConcrete>(), jsonSerializerOptions));
             schema.Annotations.Clear();
 
@@ -231,7 +231,7 @@ public static class OpenApiOptionsExtensions
                 return Task.CompletedTask;
             }
 
-            schema.Type = typeof(TType).Name;
+            schema.Type = GetTypeName<TType>();
             schema.Example = new OpenApiString(FormatJson(Activator.CreateInstance<TConcrete>(), jsonSerializerOptions));
             schema.Annotations.Clear();
 
@@ -260,7 +260,7 @@ public static class OpenApiOptionsExtensions
                 return Task.CompletedTask;
             }
 
-            schema.Type = typeof(TConcrete).Name;
+            schema.Type = GetTypeName<TConcrete>();
             schema.Format = format;
             schema.Example = new OpenApiString(FormatJson(Activator.CreateInstance<TConcrete>(), jsonSerializerOptions));
             schema.Annotations.Clear();
@@ -291,7 +291,7 @@ public static class OpenApiOptionsExtensions
                 return Task.CompletedTask;
             }
 
-            schema.Type = typeof(TType).Name;
+            schema.Type = GetTypeName<TType>();
             schema.Format = format;
             schema.Example = new OpenApiString(FormatJson(Activator.CreateInstance<TConcrete>(), jsonSerializerOptions));
             schema.Annotations.Clear();
@@ -325,7 +325,7 @@ public static class OpenApiOptionsExtensions
                 return Task.CompletedTask;
             }
 
-            schema.Type = typeof(TConcrete).Name;
+            schema.Type = GetTypeName<TConcrete>();
             schema.Format = format;
             schema.Example = new OpenApiString(FormatJson(example, jsonSerializerOptions));
             schema.Annotations.Clear();
@@ -360,7 +360,7 @@ public static class OpenApiOptionsExtensions
                 return Task.CompletedTask;
             }
 
-            schema.Type = typeof(TType).Name;
+            schema.Type = GetTypeName<TType>();
             schema.Format = format;
             schema.Example = new OpenApiString(FormatJson(example, jsonSerializerOptions));
 
@@ -398,7 +398,7 @@ public static class OpenApiOptionsExtensions
                 return Task.CompletedTask;
             }
 
-            schema.Type = typeof(TType).Name;
+            schema.Type = GetTypeName<TType>();
             schema.Format = format;
             schema.Example = new OpenApiString(FormatJson(example, jsonSerializerOptions));
             schema.Description = description;
@@ -433,7 +433,7 @@ public static class OpenApiOptionsExtensions
                 return Task.CompletedTask;
             }
 
-            schema.Type = typeof(TType).Name;
+            schema.Type = GetTypeName<TType>();
             schema.Example = new OpenApiString(FormatJson(example, jsonSerializerOptions));
             schema.Annotations.Clear();
 
@@ -467,7 +467,7 @@ public static class OpenApiOptionsExtensions
                 return Task.CompletedTask;
             }
 
-            schema.Type = typeof(TType).Name;
+            schema.Type = GetTypeName<TType>();
             schema.Example = new OpenApiString(FormatJson(example, jsonSerializerOptions));
             schema.Properties = properties ?? new Dictionary<string, OpenApiSchema>();
             schema.Annotations.Clear();
@@ -494,5 +494,15 @@ public static class OpenApiOptionsExtensions
         var jsonType = context.JsonTypeInfo.Type;
         var type = Nullable.GetUnderlyingType(jsonType) ?? jsonType;
         return type == typeof(T);
+    }
+
+    private static string GetTypeName<T>()
+    {
+        if (typeof(T) == typeof(string))
+        {
+            return "string";
+        }
+
+        return typeof(T).Name;
     }
 }

--- a/src/OpenApi.Extensions/Extensions/OpenApiOptionsExtensions.cs
+++ b/src/OpenApi.Extensions/Extensions/OpenApiOptionsExtensions.cs
@@ -197,7 +197,7 @@ public static class OpenApiOptionsExtensions
 
         options.AddSchemaTransformer((schema, context, _) =>
         {
-            if (context.JsonTypeInfo.Type != typeof(TConcrete))
+            if (!ShouldTransform<TConcrete>(context))
             {
                 return Task.CompletedTask;
             }
@@ -226,7 +226,7 @@ public static class OpenApiOptionsExtensions
 
         options.AddSchemaTransformer((schema, context, _) =>
         {
-            if (context.JsonTypeInfo.Type != typeof(TConcrete))
+            if (!ShouldTransform<TConcrete>(context))
             {
                 return Task.CompletedTask;
             }
@@ -255,7 +255,7 @@ public static class OpenApiOptionsExtensions
 
         options.AddSchemaTransformer((schema, context, _) =>
         {
-            if (context.JsonTypeInfo.Type != typeof(TConcrete))
+            if (!ShouldTransform<TConcrete>(context))
             {
                 return Task.CompletedTask;
             }
@@ -286,7 +286,7 @@ public static class OpenApiOptionsExtensions
 
         options.AddSchemaTransformer((schema, context, _) =>
         {
-            if (context.JsonTypeInfo.Type != typeof(TConcrete))
+            if (!ShouldTransform<TConcrete>(context))
             {
                 return Task.CompletedTask;
             }
@@ -320,7 +320,7 @@ public static class OpenApiOptionsExtensions
 
         options.AddSchemaTransformer((schema, context, _) =>
         {
-            if (context.JsonTypeInfo.Type != typeof(TConcrete))
+            if (!ShouldTransform<TConcrete>(context))
             {
                 return Task.CompletedTask;
             }
@@ -355,7 +355,7 @@ public static class OpenApiOptionsExtensions
 
         options.AddSchemaTransformer((schema, context, _) =>
         {
-            if (context.JsonTypeInfo.Type != typeof(TConcrete))
+            if (!ShouldTransform<TConcrete>(context))
             {
                 return Task.CompletedTask;
             }
@@ -393,7 +393,7 @@ public static class OpenApiOptionsExtensions
 
         options.AddSchemaTransformer((schema, context, _) =>
         {
-            if (context.JsonTypeInfo.Type != typeof(TConcrete))
+            if (!ShouldTransform<TConcrete>(context))
             {
                 return Task.CompletedTask;
             }
@@ -428,7 +428,7 @@ public static class OpenApiOptionsExtensions
 
         options.AddSchemaTransformer((schema, context, _) =>
         {
-            if (context.JsonTypeInfo.Type != typeof(TConcrete))
+            if (!ShouldTransform<TConcrete>(context))
             {
                 return Task.CompletedTask;
             }
@@ -462,7 +462,7 @@ public static class OpenApiOptionsExtensions
 
         options.AddSchemaTransformer((schema, context, _) =>
         {
-            if (context.JsonTypeInfo.Type != typeof(TConcrete))
+            if (!ShouldTransform<TConcrete>(context))
             {
                 return Task.CompletedTask;
             }
@@ -487,5 +487,12 @@ public static class OpenApiOptionsExtensions
         }
 
         return formatToJson;
+    }
+
+    private static bool ShouldTransform<T>(OpenApiSchemaTransformerContext context)
+    {
+        var jsonType = context.JsonTypeInfo.Type;
+        var type = Nullable.GetUnderlyingType(jsonType) ?? jsonType;
+        return type == typeof(T);
     }
 }


### PR DESCRIPTION
Hey @MMonrad! 👋🏻

Thanks for the library! When using it, I discovered a few issues:
1. Nullable types are not handled, so if you have a DTO with an `Instant CreatedAt { get; set; }` property and an `Instant? UpdatedAt { get; set; }` property, you end up with the following schema:
```json
"createdAt": {
  "type": "String",
  "description": "Represents an instant in time (UTC) without time zone information.",
  "format": "date-time",
  "example": "1905-05-17T12:30:45Z"
},
"updatedAt": {
  "$ref": "#/components/schemas/NullableOfInstant"
}
```

Where `NullableOfInstant` is defined as

```json
"NullableOfInstant": {
  "type": "object",
  "nullable": true
},
```

After this PR, everything looks good:

```json
"createdAt": {
  "type": "string",
  "description": "Represents an instant in time (UTC) without time zone information.",
  "format": "date-time",
  "example": "1905-05-17T12:30:45Z"
},
"updatedAt": {
  "type": "string",
  "description": "Represents an instant in time (UTC) without time zone information.",
  "format": "date-time",
  "nullable": true,
  "example": "1905-05-17T12:30:45Z"
}
```

2. The NodaTime types have `"type": "String"` (with PascalCase), which isn't strictly valid JSON schema. I added a quick fix for that as well